### PR TITLE
Fixed issue with overloaded methods

### DIFF
--- a/src/main/java/com/ryantenney/metrics/spring/MeteredMethodInterceptor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/MeteredMethodInterceptor.java
@@ -39,12 +39,12 @@ class MeteredMethodInterceptor implements MethodInterceptor, MethodCallback {
 
 	protected final MetricRegistry metrics;
 	protected final Class<?> targetClass;
-	protected final Map<String, Meter> meters;
+	protected final Map<Method, Meter> meters;
 
 	public MeteredMethodInterceptor(final MetricRegistry metrics, final Class<?> targetClass) {
 		this.metrics = metrics;
 		this.targetClass = targetClass;
-		this.meters = new HashMap<String, Meter>();
+		this.meters = new HashMap<Method, Meter>();
 
 		log.debug("Creating method interceptor for class {}", targetClass.getCanonicalName());
 		log.debug("Scanning for @Metered annotated methods");
@@ -54,7 +54,7 @@ class MeteredMethodInterceptor implements MethodInterceptor, MethodCallback {
 
 	@Override
 	public Object invoke(MethodInvocation invocation) throws Throwable {
-		Meter meter = meters.get(invocation.getMethod().getName());
+		Meter meter = meters.get(invocation.getMethod());
 		if (meter != null) {
 			meter.mark();
 		}
@@ -67,7 +67,7 @@ class MeteredMethodInterceptor implements MethodInterceptor, MethodCallback {
 		final String metricName = Util.forMeteredMethod(targetClass, method, annotation);
 		final Meter meter = metrics.meter(metricName);
 
-		meters.put(method.getName(), meter);
+		meters.put(method, meter);
 
 		log.debug("Created metric {} for method {}", metricName, method.getName());
 	}

--- a/src/main/java/com/ryantenney/metrics/spring/TimedMethodInterceptor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/TimedMethodInterceptor.java
@@ -40,12 +40,12 @@ class TimedMethodInterceptor implements MethodInterceptor, MethodCallback, Order
 
 	private final MetricRegistry metrics;
 	private final Class<?> targetClass;
-	private final Map<String, Timer> timers;
+	private final Map<Method, Timer> timers;
 
 	public TimedMethodInterceptor(final MetricRegistry metrics, final Class<?> targetClass) {
 		this.metrics = metrics;
 		this.targetClass = targetClass;
-		this.timers = new HashMap<String, Timer>();
+		this.timers = new HashMap<Method, Timer>();
 
 		log.debug("Creating method interceptor for class {}", targetClass.getCanonicalName());
 		log.debug("Scanning for @Timed annotated methods");
@@ -55,7 +55,7 @@ class TimedMethodInterceptor implements MethodInterceptor, MethodCallback, Order
 
 	@Override
 	public Object invoke(MethodInvocation invocation) throws Throwable {
-		final Timer timer = timers.get(invocation.getMethod().getName());
+		final Timer timer = timers.get(invocation.getMethod());
 		final com.yammer.metrics.Timer.Context timerCtx = timer != null ? timer.time() : null;
 		try {
 			return invocation.proceed();
@@ -72,7 +72,7 @@ class TimedMethodInterceptor implements MethodInterceptor, MethodCallback, Order
 		final String metricName = Util.forTimedMethod(targetClass, method, annotation);
 		final Timer timer = metrics.timer(metricName);
 
-		timers.put(method.getName(), timer);
+		timers.put(method, timer);
 
 		log.debug("Created metric {} for method {}", metricName, method.getName());
 	}


### PR DESCRIPTION
This is a fix for the overloaded methods issue where two methods with the same method name in a class cannot have different metrics annotations. Only the method name was used as the cache key to find the metric instance and this PR changes it to use the entire method signature.

Related to #12
