### PR TITLE
Use SmartLifecycle instead of Lifecycle for Spring beans lifecycle management

### DIFF
--- a/src/main/java/com/ryantenney/metrics/spring/reporter/AbstractScheduledReporterFactoryBean.java
+++ b/src/main/java/com/ryantenney/metrics/spring/reporter/AbstractScheduledReporterFactoryBean.java
@@ -16,16 +16,15 @@
  */
 package com.ryantenney.metrics.spring.reporter;
 
+import com.codahale.metrics.ScheduledReporter;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.SmartLifecycle;
+
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.context.Lifecycle;
-
-import com.codahale.metrics.ScheduledReporter;
-
-public abstract class AbstractScheduledReporterFactoryBean<T extends ScheduledReporter> extends AbstractReporterFactoryBean<T> implements Lifecycle,
+public abstract class AbstractScheduledReporterFactoryBean<T extends ScheduledReporter> extends AbstractReporterFactoryBean<T> implements SmartLifecycle,
 		DisposableBean {
 
 	private static final Pattern DURATION_STRING_PATTERN = Pattern.compile("^(\\d+)\\s?(ns|us|ms|s|m|h|d)?$");
@@ -103,4 +102,19 @@ public abstract class AbstractScheduledReporterFactoryBean<T extends ScheduledRe
 		return sourceUnit.toNanos(sourceDuration);
 	}
 
+    @Override
+    public int getPhase() {
+        return 0;
+    }
+
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return true;
+    }
 }

--- a/src/main/java/com/ryantenney/metrics/spring/reporter/JmxReporterFactoryBean.java
+++ b/src/main/java/com/ryantenney/metrics/spring/reporter/JmxReporterFactoryBean.java
@@ -16,17 +16,15 @@
  */
 package com.ryantenney.metrics.spring.reporter;
 
-import java.util.concurrent.TimeUnit;
-
-import javax.management.MBeanServer;
-
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.context.Lifecycle;
-
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricFilter;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.SmartLifecycle;
 
-public class JmxReporterFactoryBean extends AbstractReporterFactoryBean<JmxReporter> implements Lifecycle, DisposableBean {
+import javax.management.MBeanServer;
+import java.util.concurrent.TimeUnit;
+
+public class JmxReporterFactoryBean extends AbstractReporterFactoryBean<JmxReporter> implements SmartLifecycle, DisposableBean {
 
 	// Optional
 	public static final String DOMAIN = "domain";
@@ -99,4 +97,19 @@ public class JmxReporterFactoryBean extends AbstractReporterFactoryBean<JmxRepor
 		stop();
 	}
 
+    @Override
+    public boolean isAutoStartup() {
+        return true;
+    }
+
+    @Override
+    public void stop(Runnable runnable) {
+        stop();
+        runnable.run();
+    }
+
+    @Override
+    public int getPhase() {
+        return 0;
+    }
 }


### PR DESCRIPTION
Hello, Ryan.
I see you are using Spring `Lifecycle` interface to listen for container start/stop events. In some cases (e.g on context refresh) `Lifecycle#start` method will not be called by `DefaultLifecycleProcessor`, so `SmartLifecycle` seems more appropriate.

Please see `org.springframework.context.support.DefaultLifecycleProcessor#doStart`:

``` java
if (!autoStartupOnly || (bean instanceof SmartLifecycle && ((SmartLifecycle) bean).isAutoStartup())) {
```

We can overcome this by implementing `SmartLifecycle` instead of `Lifecycle` with `isAutoStartup` method returning `true`.
