### PR TITLE
Resolving host upon creation

### DIFF
--- a/src/main/java/com/ryantenney/metrics/spring/reporter/GraphiteReporterFactoryBean.java
+++ b/src/main/java/com/ryantenney/metrics/spring/reporter/GraphiteReporterFactoryBean.java
@@ -71,7 +71,8 @@ public class GraphiteReporterFactoryBean extends AbstractScheduledReporterFactor
 			reporter.filter(getPropertyRef(FILTER_REF, MetricFilter.class));
 		}
 
-		final InetSocketAddress address = InetSocketAddress.createUnresolved(getProperty(HOST), getProperty(PORT, Integer.TYPE));
+        // This resolves the hostname as the Graphite reporter is using the address, not the host
+		final InetSocketAddress address = new InetSocketAddress(getProperty(HOST), getProperty(PORT, Integer.TYPE));
 
 		return reporter.build(new Graphite(address));
 	}


### PR DESCRIPTION
The Graphite class uses

``` java
this.socket = socketFactory.createSocket(address.getAddress(), address.getPort());
```

Which doesn't resolve when the InetSocketAddress

``` java
final InetSocketAddress address = InetSocketAddress.createUnresolved(getProperty(HOST), getProperty(PORT, Integer.TYPE));
```

is used.  Am I missing something?  (the former works, the latter doesn't...)
