### PR TITLE
Add metrics-jersey support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.ryantenney.metrics</groupId>
 	<artifactId>metrics-spring</artifactId>
-	<version>3.0.0-RC3-SNAPSHOT</version>
+	<version>3.0.0-RC3-SNAPSHOT-EHpatch</version>
 	<name>Metrics Spring Integration</name>
 	<packaging>bundle</packaging>
 
@@ -115,6 +115,12 @@
 			<version>${metrics.version}</version>
 			<optional>true</optional>
 		</dependency>
+        <dependency>
+            <groupId>com.codahale.metrics</groupId>
+            <artifactId>metrics-jersey</artifactId>
+            <version>${metrics.version}</version>
+            <optional>true</optional>
+        </dependency>
 
 		<dependency>
 			<groupId>org.hamcrest</groupId>
@@ -168,8 +174,18 @@
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
 				</exclusion>
+                <exclusion>
+                    <artifactId>jersey-core</artifactId>
+                    <groupId>com.sun.jersey</groupId>
+                </exclusion>
 			</exclusions>
 		</dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-core</artifactId>
+            <version>1.17.1</version>
+        </dependency>
+        
 	</dependencies>
 
 	<build>
@@ -388,5 +404,4 @@
 			</build>
 		</profile>
 	</profiles>
-
 </project>

--- a/src/main/java/com/ryantenney/metrics/spring/config/MetricRegistryBeanDefinitionParser.java
+++ b/src/main/java/com/ryantenney/metrics/spring/config/MetricRegistryBeanDefinitionParser.java
@@ -24,27 +24,25 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 
 /**
  * Has the side effect of registering 'name' as aliases
  */
-class MetricRegistryBeanDefinitionParser extends AbstractBeanDefinitionParser {
+public class MetricRegistryBeanDefinitionParser extends AbstractBeanDefinitionParser {
+    public final static String DEFAULT_NAME = "springMetrics";
 
 	@Override
 	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
 		final Object source = parserContext.extractSource(element);
-		final String name = element.getAttribute("name");
-		if (StringUtils.hasText(name)) {
-			final BeanDefinitionBuilder beanDefBuilder = build(SharedMetricRegistries.class, source);
-			beanDefBuilder.setFactoryMethod("getOrCreate");
-			beanDefBuilder.addConstructorArgValue(name);
-			return beanDefBuilder.getBeanDefinition();
+		String name = element.getAttribute("name");
+		if (! StringUtils.hasText(name)) {
+		    name = DEFAULT_NAME;
 		}
-		else {
-			return build(MetricRegistry.class, source).getBeanDefinition();
-		}
+		final BeanDefinitionBuilder beanDefBuilder = build(SharedMetricRegistries.class, source);
+		beanDefBuilder.setFactoryMethod("getOrCreate");
+		beanDefBuilder.addConstructorArgValue(name);
+		return beanDefBuilder.getBeanDefinition();
 	}
 
 	@Override

--- a/src/main/java/com/ryantenney/metrics/spring/jersey/JerseyInstrumentedMethodDispatchAdapter.java
+++ b/src/main/java/com/ryantenney/metrics/spring/jersey/JerseyInstrumentedMethodDispatchAdapter.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ryantenney.metrics.spring.jersey;
+
+import java.util.Set;
+
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import com.codahale.metrics.jersey.InstrumentedResourceMethodDispatchAdapter;
+import com.ryantenney.metrics.spring.config.MetricRegistryBeanDefinitionParser;
+
+/**
+ * Autowire in the jaxrs provider to support @Timed within jersey
+ * Need to include the following in your web.xml:
+ *  <servlet>
+ *       <servlet-name>jersey</servlet-name>
+ *       <servlet-class>
+ *           com.sun.jersey.spi.spring.container.servlet.SpringServlet</servlet-class>
+ *       <init-param>
+ *           <param-name>com.sun.jersey.config.property.resourceConfigClass</param-name>
+ *           <param-value>com.sun.jersey.api.core.PackagesResourceConfig</param-value>
+ *       </init-param>
+ *       <init-param>
+ *           <param-name>com.sun.jersey.config.property.packages</param-name>
+ *           <param-value>com.ryantenney</param-value>
+ *       </init-param>
+ *   </servlet>
+ *
+ * NOTE: Do not scan the metrics-jersey packages or you will get a NPE
+ * 
+ */
+@Provider
+public class JerseyInstrumentedMethodDispatchAdapter extends InstrumentedResourceMethodDispatchAdapter {
+    private static Logger logger = LoggerFactory.getLogger(JerseyInstrumentedMethodDispatchAdapter.class);
+     
+    
+    public JerseyInstrumentedMethodDispatchAdapter() {
+        //todo: find a way to wire in a differently named metric registry
+        this(getMetricsRegristry());
+    }
+    public JerseyInstrumentedMethodDispatchAdapter(String name) {
+        this(SharedMetricRegistries.getOrCreate(name));
+    }
+
+    public JerseyInstrumentedMethodDispatchAdapter(MetricRegistry registry) {
+        super(registry);
+        logger.info("Instrumenting jersey classes");
+    }
+
+    private  static MetricRegistry getMetricsRegristry() {
+        Set<String> names = SharedMetricRegistries.names();
+        final String name;
+        if (names.size() == 0) {
+            name = MetricRegistryBeanDefinitionParser.DEFAULT_NAME;
+            logger.warn("Could not find a shared metrics registry, using default name {}", name);
+        } else if (names.size() == 1) {
+            name = names.iterator().next();
+            logger.info("Using metric registry {}", name);
+        } else {
+            name = names.iterator().next();
+            logger.warn("Multiple metrics registries have beenCould not find a shared metrics registry, taking first name {}", name);
+        }
+        return SharedMetricRegistries.getOrCreate(name);
+    }
+
+}


### PR DESCRIPTION
Supports metrics-jersey.
Unfortunately only supports one metrics registry.
Really need a better way to wire in the metrics registry. Perhaps a MetricsRegistryProvider and an xml setting + annotation way of providing them.

Also unfortunately, always creates metrics registries in the SharedMetricRegistries.

Tried to find a better way to wire in spring beans but @InjectParam (which is jersey specific only) did not work. This class likely works with non-jersey jaxrs implementations but I have not tested them.

As before, i can create unit tests for this if you want to merge them in, however these have been manually tested and do work.
