### PR TITLE
fix metrics field injection into AOP-advised beans

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjweaver</artifactId>
+			<version>1.7.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<version>1.0.11</version>

--- a/src/main/java/com/ryantenney/metrics/spring/InjectMetricAnnotationBeanPostProcessor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/InjectMetricAnnotationBeanPostProcessor.java
@@ -46,12 +46,7 @@ class InjectMetricAnnotationBeanPostProcessor implements BeanPostProcessor, Orde
 	}
 
 	@Override
-	public Object postProcessBeforeInitialization(Object bean, String beanName) {
-		return bean;
-	}
-
-	@Override
-	public Object postProcessAfterInitialization(final Object bean, String beanName) {
+	public Object postProcessBeforeInitialization(final Object bean, String beanName) {
 		final Class<?> targetClass = AopUtils.getTargetClass(bean);
 
 		ReflectionUtils.doWithFields(targetClass, new FieldCallback() {
@@ -85,6 +80,11 @@ class InjectMetricAnnotationBeanPostProcessor implements BeanPostProcessor, Orde
 			}
 		}, FILTER);
 
+		return bean;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) {
 		return bean;
 	}
 

--- a/src/test/java/com/ryantenney/metrics/spring/AopFieldInjectionInteractionTest.java
+++ b/src/test/java/com/ryantenney/metrics/spring/AopFieldInjectionInteractionTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ryantenney.metrics.spring;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.ryantenney.metrics.annotation.InjectMetric;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:aop-field-injection-interaction.xml")
+public class AopFieldInjectionInteractionTest {
+
+	@Autowired private MetricRegistry metricRegistry;
+	@Autowired private TestAspectTarget target;
+
+	@Test
+	public void testFieldInjectionShouldNotCauseErrorWhenTargetIsAopProxy() throws Exception {
+		// verify that AOP interception is working
+		assertThat(target.targetMethod(), is(5));
+
+		assertThat(metricRegistry.getCounters(), hasKey("targetCounter"));
+		assertThat(metricRegistry.getCounters().get("targetCounter").getCount(), is(1L));
+	}
+
+}
+
+@Aspect
+class TestAspectWrapper {
+
+	@Around("execution(* com.ryantenney.metrics.spring.TestAspectTarget.targetMethod())")
+	public Object aroundMethod(ProceedingJoinPoint joinPoint) throws Throwable {
+		joinPoint.proceed();
+		return 5;
+	}
+
+}
+
+interface TestAspectTarget {
+
+	public int targetMethod();
+
+}
+
+class TestAspectTargetImpl implements TestAspectTarget {
+
+	@InjectMetric(name = "targetCounter", absolute = true) private Counter counter;
+
+	@Override
+	public int targetMethod() {
+		this.counter.inc();
+		return 3;
+	}
+
+}

--- a/src/test/java/com/ryantenney/metrics/spring/TestSuite.java
+++ b/src/test/java/com/ryantenney/metrics/spring/TestSuite.java
@@ -25,6 +25,7 @@ import com.codahale.metrics.SharedMetricRegistries;
 @RunWith(Suite.class)
 // @formatter:off
 @SuiteClasses({
+		AopFieldInjectionInteractionTest.class,
 		CovariantReturnTypeTest.class,
 		EnableMetricsTest.class,
 		HealthCheckTest.class,

--- a/src/test/resources/aop-field-injection-interaction.xml
+++ b/src/test/resources/aop-field-injection-interaction.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:aop="http://www.springframework.org/schema/aop"
+    xmlns:metrics="http://www.ryantenney.com/schema/metrics"
+
+    xsi:schemaLocation="
+            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
+            http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.2.xsd
+            http://www.ryantenney.com/schema/metrics http://www.ryantenney.com/schema/metrics/metrics-3.0.xsd">
+
+    <aop:aspectj-autoproxy />
+
+    <metrics:annotation-driven />
+
+    <bean class="com.ryantenney.metrics.spring.TestAspectWrapper" />
+    <bean class="com.ryantenney.metrics.spring.TestAspectTargetImpl" />
+
+</beans>


### PR DESCRIPTION
When injecting metrics into annotated fields of AOP proxied beans, the
bean post processor was attempting to inject the values into the proxy
instance, not the underlying bean.  Since the fields in question didn't
exist, this would cause an error.  Instead, perform the injection at an
earlier phase of bean post-processing, which targets the underlying
bean, not the proxy wrapper.
