### PR TITLE
clean up POM transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 		<metrics.version>3.0.1</metrics.version>
 		<spring.version>3.2.4.RELEASE</spring.version>
 		<slf4j.version>1.7.5</slf4j.version>
+		<hamcrest.version>1.3</hamcrest.version>
 	</properties>
 
 	<developers>
@@ -87,6 +88,12 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 			<version>${spring.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>commons-logging</artifactId>
+					<groupId>commons-logging</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -124,13 +131,13 @@
 
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
+			<artifactId>hamcrest-library</artifactId>
+			<version>${hamcrest.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<artifactId>junit-dep</artifactId>
 			<version>4.10</version>
 			<scope>test</scope>
 		</dependency>
@@ -177,6 +184,16 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.hamcrest</groupId>
+				<artifactId>hamcrest-core</artifactId>
+				<version>${hamcrest.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
- exclude commons-logging, since the SLF4J Commons Logging replacement
  is installed
- don't use the version of JUnit with embedded Hamcrest; instead pull
  Hamcrest in through transitive dependencies
- ensure that all modules of Hamcrest are the same version
- use individual Hamcrest libraries instead of bundle to leverage
  Maven's version conflict resolution
