### PR TITLE
Add tool namespace for type checking and code completion

### DIFF
--- a/src/main/resources/com/ryantenney/metrics/spring/config/metrics-3.0.xsd
+++ b/src/main/resources/com/ryantenney/metrics/spring/config/metrics-3.0.xsd
@@ -89,7 +89,11 @@
         <xsd:annotation>
             <xsd:appinfo>
                 <tool:annotation>
-                    <tool:exports type="com.codahale.metrics.ScheduledReporter"/>
+                    <tool:exports type="com.codahale.metrics.Slf4jReporter"/>
+                    <tool:exports type="com.codahale.metrics.ConsoleReporter"/>
+                    <tool:exports type="com.codahale.metrics.JmxReporter"/>
+                    <tool:exports type="com.codahale.metrics.ganglia.GangliaReporter"/>
+                    <tool:exports type="com.codahale.metrics.graphite.GraphiteReporter"/>
                 </tool:annotation>
             </xsd:appinfo>
         </xsd:annotation>


### PR DESCRIPTION
Spring has a tooling namespace that helps writers of custom namespaces integrate their schema with the various IDEs that support Spring XML code completion and type checking. I have added this capability to the metrics-spring namespace.
It works by adding a XML schema `annotation` element and placing the tool namespace elements inside. From there elements are added for telling what types the custom element exports and whether or not the attribute is a reference or a direct type.

``` XML
<xsd:annotation>
    <xsd:appinfo>
        <tool:annotation>
            <tool:exports type="com.codahale.metrics.MetricRegistry"/>
        </tool:annotation>
    </xsd:appinfo>
</xsd:annotation>
```

Now when the metrics-spring namespace is loaded in a IDE like IntelliJ IDEA, the editor immediately knows how the namespace works and is able to provide code completion, suggestions, and report errors about incorrect types and references. No manual scanning of the namespace is required.
