### PR TITLE
fixed OSGi deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
 							org.springframework.cglib.core,
 							org.springframework.cglib.proxy,
 							org.springframework.cglib.reflect,
+                            javax.servlet;version="[3.0,4)";resolution:=optional,
 							*
 						]]></Import-Package>
 					</instructions>


### PR DESCRIPTION
the problem is that the default import for javax.servlet was pulling in
servlet 3.1, this change makes servlet optional and works starting from
3.0
