### PR TITLE
Reporter Bean Parser rejects attributes that declare namespaces (e.g. xmlns:context="...")

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ryantenney.metrics</groupId>
 	<artifactId>metrics-spring</artifactId>
-	<version>3.0.2</version>
+    <version>3.0.3-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<name>Metrics Spring Integration</name>
 	<description>Spring integration for Coda Hale's Metrics Library</description>

--- a/src/main/java/com/ryantenney/metrics/annotation/CachedGauge.java
+++ b/src/main/java/com/ryantenney/metrics/annotation/CachedGauge.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 /**
  * An annotation for marking a method as a gauge, which caches the result for a specified time.
  *
- * <p/>
  * Given a method like this:
  * <pre><code>
  *     {@literal @}CachedGauge(name = "queueSize", timeout = 30, timeoutUnit = TimeUnit.SECONDS)
@@ -33,7 +32,6 @@ import java.util.concurrent.TimeUnit;
  *     }
  * 
  * </code></pre>
- * <p/>
  * 
  * A gauge for the defining class with the name queueSize will be created which uses the annotated method's
  * return value as its value, and which caches the result for 30 seconds.

--- a/src/main/java/com/ryantenney/metrics/annotation/Counted.java
+++ b/src/main/java/com/ryantenney/metrics/annotation/Counted.java
@@ -23,7 +23,6 @@ import java.lang.annotation.Target;
 /**
  * An annotation for marking a method of an annotated object as counted.
  *
- * <p/>
  * Given a method like this:
  * <pre><code>
  *     {@literal @}Counted(name = "fancyName")
@@ -31,7 +30,7 @@ import java.lang.annotation.Target;
  *         return "Sir Captain " + name;
  *     }
  * </code></pre>
- * <p/>
+ * 
  * A counter for the defining class with the name {@code fancyName} will be created and each time the
  * {@code #fancyName(String)} method is invoked, the counter will be marked.
  */

--- a/src/main/java/com/ryantenney/metrics/annotation/Metric.java
+++ b/src/main/java/com/ryantenney/metrics/annotation/Metric.java
@@ -23,25 +23,22 @@ import java.lang.annotation.Target;
 /**
  * An annotation requesting that a metric be injected or registered.
  *
- * <p/>
  * Given a field like this:
  * <pre><code>
  *     {@literal @}Metric
  *     public Histogram histogram;
  * </code></pre>
- * <p/>
+ * 
  * A meter of the field's type will be created and injected into Spring-managed beans after construction
  * but before initialization. It will be up to the user to interact with the metric. This annotation
  * can be used on fields of type Meter, Timer, Counter, and Histogram.
  * 
- * <p>
  * This may also be used to register a metric, which is useful for creating a histogram with
  * a custom Reservoir.
  * <pre><code>
  *     {@literal @}Metric
  *     public Histogram uniformHistogram = new Histogram(new UniformReservoir());
  * </code></pre>
- * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/src/main/java/com/ryantenney/metrics/spring/config/annotation/MetricsConfigurationSupport.java
+++ b/src/main/java/com/ryantenney/metrics/spring/config/annotation/MetricsConfigurationSupport.java
@@ -28,11 +28,12 @@ import org.springframework.util.Assert;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.ryantenney.metrics.spring.MetricsBeanPostProcessorFactory;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * This is the main class providing the configuration behind the Metrics Java config.
  * It is typically imported by adding {@link EnableMetrics @EnableMetrics} to an
- * application {@link Configuration @Configuration} class.
+ * application {@link Configuration } class.
  *
  * @see MetricsConfigurer
  * @see MetricsConfigurerAdapter

--- a/src/test/java/com/ryantenney/metrics/spring/reporter/AbstractReporterElementParserTest.java
+++ b/src/test/java/com/ryantenney/metrics/spring/reporter/AbstractReporterElementParserTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ryantenney.metrics.spring.reporter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Test for {@link AbstractReporterElementParser#validate(java.util.Map)}
+ *
+ * @author Dana P'Simer&lt;danap@bluesoftdev.com&gt;
+ */
+public class AbstractReporterElementParserTest {
+
+    AbstractReporterElementParser target = new AbstractReporterElementParser() {
+
+        @Override
+        public String getType() {
+            return "test";
+        }
+
+        @Override
+        protected void validate(AbstractReporterElementParser.ValidationContext c) {
+            c.require("required");
+            c.require("requiredRegex", "[0-9]*");
+            c.optional("optional");
+            c.optional("optionalRegex", "[a-zA-z]*", "Must be only alphabetic characters");
+            c.rejectUnmatchedProperties();
+        }
+    };
+
+    @Test
+    public void testValidate() {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("required", "requiredValue");
+        properties.put("requiredRegex", "42");
+        properties.put("optionalRegex", "abcd");
+        target.validate(properties);
+    }
+
+    @Test
+    public void testValidateNotRequired() {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("optionalRegex", "abcd");
+        try {
+            target.validate(properties);
+            fail();
+        } catch (AbstractReporterElementParser.ValidationException ex) {
+        }
+    }
+
+    @Test
+    public void testValidateBadRequired() {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("required", "requiredValue");
+        properties.put("requriedRegex", "42");
+        properties.put("optionalRegex", "abcd");
+        try {
+            target.validate(properties);
+            fail();
+        } catch (AbstractReporterElementParser.ValidationException ex) {
+        }
+    }
+
+    @Test
+    public void testValidateBadOptional() {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("required", "requiredValue");
+        properties.put("optionalRegex", "a5bcd");
+        try {
+            target.validate(properties);
+            fail();
+        } catch (AbstractReporterElementParser.ValidationException ex) {
+        }
+    }
+
+    @Test
+    public void testValidateWithNamespaceDefinitions() {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("xmlns:foo", "http://foo.com/foo http://foo.com/foo/v1/foo.xsd");
+        properties.put("required", "requiredValue");
+        properties.put("requiredRegex", "42");
+        properties.put("optionalRegex", "abcd");
+        target.validate(properties);
+    }
+}


### PR DESCRIPTION
The AbstractReporterElementParser has a method in it's ValidationContext class called "rejectUnmatchedProperties".  This modification changes the behavior of this method to ignore attributes that have a namespace specifier (e.g. "xmlns:context").  In XML namespaces can be defined on any element and attributes can be applied to elements from other namespaces.  The XML spec defines that these should be ignored when processing elements by processors that do not understand them.

One could argue that rejecting unknown properties (i.e. attributes) is not a good idea since as an eXtensible Markup Language, XML allows adding attributes to elements that will not be known by older processors.  However, the advantage of detecting attributes that don't belong may out weight that concern.