### PR TITLE
use latest release version of metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<metrics.version>3.1.1-SNAPSHOT</metrics.version>
+		<metrics.version>3.1.1</metrics.version>
 		<rabbitmq.version>3.3.5</rabbitmq.version>
 		<librato.version>4.0.1.3</librato.version>
 		<spring.version>4.1.0.RELEASE</spring.version>


### PR DESCRIPTION
Could you do a release soon so that new outputs (ganglia/graphite) could be supported and use features from metrics 3.1.1?