### PR TITLE
Added support for @CompositeTimed annotation

### DIFF
--- a/src/main/java/com/ryantenney/metrics/CompositeTimer.java
+++ b/src/main/java/com/ryantenney/metrics/CompositeTimer.java
@@ -1,0 +1,35 @@
+package com.ryantenney.metrics;
+
+import com.codahale.metrics.Timer;
+
+/**
+ *
+ */
+public class CompositeTimer
+{
+    private final Timer totalTimer;
+    private final Timer successTimer;
+    private final Timer failureTimer;
+
+    public CompositeTimer(final Timer totalTimer, final Timer successTimer, final Timer failureTimer)
+    {
+        this.totalTimer = totalTimer;
+        this.successTimer = successTimer;
+        this.failureTimer = failureTimer;
+    }
+
+    public Timer getTotalTimer()
+    {
+        return totalTimer;
+    }
+
+    public Timer getSuccessTimer()
+    {
+        return successTimer;
+    }
+
+    public Timer getFailureTimer()
+    {
+        return failureTimer;
+    }
+}

--- a/src/main/java/com/ryantenney/metrics/annotation/CompositeTimed.java
+++ b/src/main/java/com/ryantenney/metrics/annotation/CompositeTimed.java
@@ -1,0 +1,51 @@
+package com.ryantenney.metrics.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a method of an annotated object as composite timed.
+ * <p/>
+ * Given a method like this:
+ * <pre><code>
+ *     {@literal @}CompositeTimed(name = "fancyName")
+ *     public String fancyName(String name) {
+ *         return "Sir Captain " + name;
+ *     }
+ * </code></pre>
+ * <p/>
+ * Three timers for the defining class with the name {@code fancyName} will be created:
+ * <ul>
+ *     <li>One to time all the method calls</li>
+ *     <li>One to time all successful method calls</li>
+ *     <li>One to time all failing method calls</li>
+ * </ul>
+ * and each time the
+ * {@code #fancyName(String)} method is invoked, the method's execution will be timed.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CompositeTimed {
+    /**
+     * The name of the timer.
+     */
+    String name() default "";
+
+    /**
+     * The suffix for the successful timer.
+     */
+    String successSuffix() default ".success";
+
+    /**
+     * The suffix for the failing timer.
+     */
+    String failedSuffix() default ".failed";
+
+    /**
+     * If {@code true}, use the given name as an absolute name. If {@code false}, use the given name
+     * relative to the annotated class.
+     */
+    boolean absolute() default false;
+}

--- a/src/main/java/com/ryantenney/metrics/spring/CompositeTimedMethodInterceptor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/CompositeTimedMethodInterceptor.java
@@ -1,0 +1,88 @@
+package com.ryantenney.metrics.spring;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.ryantenney.metrics.CompositeTimer;
+import com.ryantenney.metrics.annotation.CompositeTimed;
+import org.aopalliance.aop.Advice;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.core.Ordered;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import static com.ryantenney.metrics.spring.AnnotationFilter.PROXYABLE_METHODS;
+
+public class CompositeTimedMethodInterceptor extends AbstractMetricMethodInterceptor<CompositeTimed, CompositeTimer> implements Ordered
+{
+    public static final Class<CompositeTimed> ANNOTATION = CompositeTimed.class;
+    public static final Pointcut POINTCUT = new AnnotationMatchingPointcut(null, ANNOTATION);
+    public static final ReflectionUtils.MethodFilter METHOD_FILTER = new AnnotationFilter(ANNOTATION, PROXYABLE_METHODS);
+
+    public CompositeTimedMethodInterceptor(final MetricRegistry metricRegistry, final Class<?> targetClass)
+    {
+        super(metricRegistry, targetClass, ANNOTATION, METHOD_FILTER);
+    }
+
+    @Override
+    protected Object invoke(final MethodInvocation invocation, final CompositeTimer metric, final CompositeTimed annotation) throws Throwable
+    {
+        final Timer.Context timerCtx = metric.getTotalTimer().time();
+        boolean success = true;
+        final Object result;
+        try
+        {
+            result = invocation.proceed();
+        }
+        catch (Throwable t)
+        {
+            success = false;
+            throw  t;
+        }
+        finally
+        {
+            final long elapsed = timerCtx.stop();
+            updateTimer(success ? metric.getSuccessTimer() : metric.getFailureTimer(), elapsed);
+        }
+
+        return result;
+    }
+
+    private void updateTimer(final Timer timer, final long elapsed)
+    {
+        timer.update(elapsed, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    protected CompositeTimer buildMetric(MetricRegistry metricRegistry, String metricName, CompositeTimed annotation)
+    {
+        final Timer totalTimer = metricRegistry.timer(metricName);
+        final Timer successTimer = metricRegistry.timer(metricName + annotation.successSuffix());
+        final Timer failureTimer = metricRegistry.timer(metricName + annotation.failedSuffix());
+        return new CompositeTimer(totalTimer, successTimer, failureTimer);
+    }
+
+    @Override
+    protected String buildMetricName(Class<?> targetClass, Method method, CompositeTimed annotation)
+    {
+        return Util.chooseName(annotation.name(), annotation.absolute(), targetClass, method);
+    }
+
+    @Override
+    public int getOrder()
+    {
+        return HIGHEST_PRECEDENCE;
+    }
+
+    static AdviceFactory adviceFactory(final MetricRegistry metricRegistry) {
+        return new AdviceFactory() {
+            @Override
+            public Advice getAdvice(Object bean, Class<?> targetClass) {
+                return new CompositeTimedMethodInterceptor(metricRegistry, targetClass);
+            }
+        };
+    }
+}

--- a/src/main/java/com/ryantenney/metrics/spring/CompositeTimedMethodInterceptor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/CompositeTimedMethodInterceptor.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.ryantenney.metrics.spring.AnnotationFilter.PROXYABLE_METHODS;
 
-public class CompositeTimedMethodInterceptor extends AbstractMetricMethodInterceptor<CompositeTimed, CompositeTimer> implements Ordered
+class CompositeTimedMethodInterceptor extends AbstractMetricMethodInterceptor<CompositeTimed, CompositeTimer> implements Ordered
 {
     public static final Class<CompositeTimed> ANNOTATION = CompositeTimed.class;
     public static final Pointcut POINTCUT = new AnnotationMatchingPointcut(null, ANNOTATION);
@@ -57,7 +57,7 @@ public class CompositeTimedMethodInterceptor extends AbstractMetricMethodInterce
     }
 
     @Override
-    protected CompositeTimer buildMetric(MetricRegistry metricRegistry, String metricName, CompositeTimed annotation)
+    protected CompositeTimer buildMetric(final MetricRegistry metricRegistry, final String metricName, final CompositeTimed annotation)
     {
         final Timer totalTimer = metricRegistry.timer(metricName);
         final Timer successTimer = metricRegistry.timer(metricName + annotation.successSuffix());
@@ -66,7 +66,7 @@ public class CompositeTimedMethodInterceptor extends AbstractMetricMethodInterce
     }
 
     @Override
-    protected String buildMetricName(Class<?> targetClass, Method method, CompositeTimed annotation)
+    protected String buildMetricName(final Class<?> targetClass, final Method method, final CompositeTimed annotation)
     {
         return Util.chooseName(annotation.name(), annotation.absolute(), targetClass, method);
     }

--- a/src/main/java/com/ryantenney/metrics/spring/MetricsBeanPostProcessorFactory.java
+++ b/src/main/java/com/ryantenney/metrics/spring/MetricsBeanPostProcessorFactory.java
@@ -37,6 +37,12 @@ public class MetricsBeanPostProcessorFactory {
 		return new AdvisingBeanPostProcessor(TimedMethodInterceptor.POINTCUT, TimedMethodInterceptor.adviceFactory(metricRegistry), proxyConfig);
 	}
 
+	public static AdvisingBeanPostProcessor compositeTimed(final MetricRegistry metricRegistry, final ProxyConfig
+			proxyConfig) {
+		return new AdvisingBeanPostProcessor(CompositeTimedMethodInterceptor.POINTCUT, CompositeTimedMethodInterceptor.adviceFactory(metricRegistry),
+				proxyConfig);
+	}
+
 	public static AdvisingBeanPostProcessor counted(final MetricRegistry metricRegistry, final ProxyConfig proxyConfig) {
 		return new AdvisingBeanPostProcessor(CountedMethodInterceptor.POINTCUT, CountedMethodInterceptor.adviceFactory(metricRegistry), proxyConfig);
 	}

--- a/src/main/java/com/ryantenney/metrics/spring/Util.java
+++ b/src/main/java/com/ryantenney/metrics/spring/Util.java
@@ -24,6 +24,7 @@ import com.codahale.metrics.annotation.Gauge;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.ryantenney.metrics.annotation.CachedGauge;
+import com.ryantenney.metrics.annotation.CompositeTimed;
 import com.ryantenney.metrics.annotation.Counted;
 import com.ryantenney.metrics.annotation.Metric;
 
@@ -32,6 +33,10 @@ class Util {
 	private Util() {}
 
 	static String forTimedMethod(Class<?> klass, Member member, Timed annotation) {
+		return chooseName(annotation.name(), annotation.absolute(), klass, member);
+	}
+
+	static String forCompositeTimedMethod(Class<?> klass, Member member, CompositeTimed annotation) {
 		return chooseName(annotation.name(), annotation.absolute(), klass, member);
 	}
 

--- a/src/main/java/com/ryantenney/metrics/spring/config/AnnotationDrivenBeanDefinitionParser.java
+++ b/src/main/java/com/ryantenney/metrics/spring/config/AnnotationDrivenBeanDefinitionParser.java
@@ -83,6 +83,12 @@ class AnnotationDrivenBeanDefinitionParser implements BeanDefinitionParser {
 
 		registerComponent(parserContext,
 				build(MetricsBeanPostProcessorFactory.class, source, ROLE_INFRASTRUCTURE)
+						.setFactoryMethod("compositeTimed")
+						.addConstructorArgReference(metricsBeanName)
+						.addConstructorArgValue(proxyConfig));
+
+		registerComponent(parserContext,
+				build(MetricsBeanPostProcessorFactory.class, source, ROLE_INFRASTRUCTURE)
 					.setFactoryMethod("counted")
 					.addConstructorArgReference(metricsBeanName)
 					.addConstructorArgValue(proxyConfig));

--- a/src/main/java/com/ryantenney/metrics/spring/config/annotation/MetricsConfigurationSupport.java
+++ b/src/main/java/com/ryantenney/metrics/spring/config/annotation/MetricsConfigurationSupport.java
@@ -15,6 +15,9 @@
  */
 package com.ryantenney.metrics.spring.config.annotation;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.ryantenney.metrics.spring.MetricsBeanPostProcessorFactory;
 import org.springframework.aop.framework.ProxyConfig;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -24,10 +27,6 @@ import org.springframework.context.annotation.Role;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.Assert;
-
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.health.HealthCheckRegistry;
-import com.ryantenney.metrics.spring.MetricsBeanPostProcessorFactory;
 
 /**
  * This is the main class providing the configuration behind the Metrics Java config.
@@ -74,6 +73,12 @@ public class MetricsConfigurationSupport implements ImportAware {
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	public BeanPostProcessor timedAnnotationBeanPostProcessor() {
 		return MetricsBeanPostProcessorFactory.timed(getMetricRegistry(), proxyConfig);
+	}
+
+	@Bean
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+	public BeanPostProcessor compositeTimedAnnotationBeanPostProcessor() {
+		return MetricsBeanPostProcessorFactory.compositeTimed(getMetricRegistry(), proxyConfig);
 	}
 
 	@Bean

--- a/src/test/java/com/ryantenney/metrics/spring/CovariantReturnTypeTest.java
+++ b/src/test/java/com/ryantenney/metrics/spring/CovariantReturnTypeTest.java
@@ -15,6 +15,7 @@
  */
 package com.ryantenney.metrics.spring;
 
+import com.ryantenney.metrics.annotation.CompositeTimed;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -68,6 +69,12 @@ public class CovariantReturnTypeTest {
 	}
 
 	@Test
+	public void testCompositeTimedMethod() {
+		ctx.getBean(MeteredInterface.class).compositeTimedMethod();
+		Assert.assertTrue("No metrics should be registered", this.metricRegistry.getNames().isEmpty());
+	}
+
+	@Test
 	public void testMeteredMethod() {
 		ctx.getBean(MeteredInterface.class).meteredMethod();
 		Assert.assertTrue("No metrics should be registered", this.metricRegistry.getNames().isEmpty());
@@ -95,6 +102,9 @@ public class CovariantReturnTypeTest {
 		@Timed
 		public Number timedMethod();
 
+		@CompositeTimed
+		public Number compositeTimedMethod();
+
 		@Metered
 		public Number meteredMethod();
 
@@ -110,6 +120,11 @@ public class CovariantReturnTypeTest {
 
 		@Override
 		public Integer timedMethod() {
+			return 0;
+		}
+
+		@Override
+		public Integer compositeTimedMethod() {
 			return 0;
 		}
 

--- a/src/test/java/com/ryantenney/metrics/spring/MeteredInterfaceTest.java
+++ b/src/test/java/com/ryantenney/metrics/spring/MeteredInterfaceTest.java
@@ -15,6 +15,7 @@
  */
 package com.ryantenney.metrics.spring;
 
+import com.ryantenney.metrics.annotation.CompositeTimed;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -74,6 +75,12 @@ public class MeteredInterfaceTest {
 	}
 
 	@Test
+	public void testCompositeTimedMethod() {
+		ctx.getBean(MeteredInterface.class).compositeTimedMethod();
+		Assert.assertTrue("No metrics should be registered", this.metricRegistry.getNames().isEmpty());
+	}
+
+	@Test
 	public void testMeteredMethod() {
 		ctx.getBean(MeteredInterface.class).meteredMethod();
 		Assert.assertTrue("No metrics should be registered", this.metricRegistry.getNames().isEmpty());
@@ -101,6 +108,9 @@ public class MeteredInterfaceTest {
 		@Timed
 		public void timedMethod();
 
+		@CompositeTimed
+		public void compositeTimedMethod();
+
 		@Metered
 		public void meteredMethod();
 
@@ -116,6 +126,9 @@ public class MeteredInterfaceTest {
 
 		@Override
 		public void timedMethod() {}
+
+		@Override
+		public void compositeTimedMethod() {}
 
 		@Override
 		public void meteredMethod() {}

--- a/src/test/java/com/ryantenney/metrics/spring/TestSuite.java
+++ b/src/test/java/com/ryantenney/metrics/spring/TestSuite.java
@@ -29,7 +29,7 @@ import com.codahale.metrics.SharedMetricRegistries;
 		CovariantReturnTypeTest.class,
 		EnableMetricsTest.class,
 		HealthCheckTest.class,
-		MeteredClassImpementsInterfaceTest.class,
+		MeteredClassImplementsInterfaceTest.class,
 		MeteredClassTest.class,
 		MeteredInterfaceTest.class,
 		MetricAnnotationTest.class,

--- a/src/test/resources/metered-interface-impl.xml
+++ b/src/test/resources/metered-interface-impl.xml
@@ -28,6 +28,6 @@
 
 	<metrics:annotation-driven />
 
-	<bean id="metered-class-interface" class="com.ryantenney.metrics.spring.MeteredClassImpementsInterfaceTest.MeteredClassImpl" />
+	<bean id="metered-class-interface" class="com.ryantenney.metrics.spring.MeteredClassImplementsInterfaceTest.MeteredClassImpl" />
 
 </beans>


### PR DESCRIPTION
It can be sometimes useful having different timers on a method to avoid failing events to falsify the overall timing statistics.
The @CompositeTimed annotation adds 3 timers on a method call:
- a failure timer that tracks the duration of the method when an exception occurs
- a success timer for methods calls that end successfully
- an overall timer

```java
@CompositeTimed(name="compositeMethod", failedSuffix = "Fail", successSuffix = "Success", absolute = true)
public void compositeTimedMethod() throws Exception
{
	....
}
```
will create compositeMethod, compositeMethodSuccess and compositeMethodFail timers.

Hope this can help.