### PR TITLE
Timer customization

### DIFF
--- a/src/main/java/com/ryantenney/metrics/spring/AbstractMetricMethodInterceptor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/AbstractMetricMethodInterceptor.java
@@ -39,13 +39,17 @@ abstract class AbstractMetricMethodInterceptor<A extends Annotation, M> implemen
 	private final Class<?> targetClass;
 	private final Class<A> annotationClass;
 	private final Map<MethodKey, AnnotationMetricPair<A, M>> metrics;
+	private final MetricFactory<M, A> metricFactory;
+	private final MetricNamingStrategy<A> namingStrategy;
 
 	AbstractMetricMethodInterceptor(final MetricRegistry metricRegistry, final Class<?> targetClass, final Class<A> annotationClass,
-			final MethodFilter methodFilter) {
+			final MethodFilter methodFilter, MetricFactory<M, A> metricFactory, MetricNamingStrategy<A> namingStrategy) {
 		this.metricRegistry = metricRegistry;
 		this.targetClass = targetClass;
 		this.annotationClass = annotationClass;
+		this.metricFactory = metricFactory;
 		this.metrics = new HashMap<MethodKey, AnnotationMetricPair<A, M>>();
+		this.namingStrategy = namingStrategy;
 
 		LOG.debug("Creating method interceptor for class {}", targetClass.getCanonicalName());
 		LOG.debug("Scanning for @{} annotated methods", annotationClass.getSimpleName());
@@ -82,9 +86,13 @@ abstract class AbstractMetricMethodInterceptor<A extends Annotation, M> implemen
 		}
 	}
 
-	protected abstract MetricName buildMetricName(Class<?> targetClass, Method method, A annotation);
+	protected MetricName buildMetricName(Class<?> targetClass, Method method, A annotation) {
+		return namingStrategy.buildMetricName(targetClass, method, annotation);
+	}
 
-	protected abstract M buildMetric(MetricRegistry metricRegistry, MetricName metricName, A annotation);
+	protected M buildMetric(MetricRegistry metricRegistry, MetricName metricName, A annotation) {
+		return metricFactory.getMetric(metricRegistry, metricName, annotation);
+	}
 
 	protected abstract Object invoke(MethodInvocation invocation, M metric, A annotation) throws Throwable;
 

--- a/src/main/java/com/ryantenney/metrics/spring/CountedMethodInterceptor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/CountedMethodInterceptor.java
@@ -37,7 +37,7 @@ class CountedMethodInterceptor extends AbstractMetricMethodInterceptor<Counted, 
 	public static final MethodFilter METHOD_FILTER = new AnnotationFilter(ANNOTATION, PROXYABLE_METHODS);
 
 	public CountedMethodInterceptor(final MetricRegistry metricRegistry, final Class<?> targetClass) {
-		super(metricRegistry, targetClass, ANNOTATION, METHOD_FILTER);
+		super(metricRegistry, targetClass, ANNOTATION, METHOD_FILTER, new CounterFactory(), new CountedNamingStrategy());
 	}
 
 	@Override
@@ -53,14 +53,18 @@ class CountedMethodInterceptor extends AbstractMetricMethodInterceptor<Counted, 
 		}
 	}
 
-	@Override
-	protected Counter buildMetric(MetricRegistry metricRegistry, MetricName metricName, Counted annotation) {
-		return metricRegistry.counter(metricName);
+	static class CounterFactory implements MetricFactory<Counter, Counted> {
+		@Override
+		public Counter getMetric(MetricRegistry metricRegistry, MetricName metricName, Counted annotation) {
+			return metricRegistry.counter(metricName);
+		}
 	}
 
-	@Override
-	protected MetricName buildMetricName(Class<?> targetClass, Method method, Counted annotation) {
-		return Util.forCountedMethod(targetClass, method, annotation);
+	static class CountedNamingStrategy implements MetricNamingStrategy<Counted> {
+		@Override
+		public MetricName buildMetricName(Class<?> targetClass, Method method, Counted annotation) {
+			return Util.forCountedMethod(targetClass, method, annotation);
+		}
 	}
 
 	static AdviceFactory adviceFactory(final MetricRegistry metricRegistry) {

--- a/src/main/java/com/ryantenney/metrics/spring/ExceptionMeteredMethodInterceptor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/ExceptionMeteredMethodInterceptor.java
@@ -38,7 +38,7 @@ class ExceptionMeteredMethodInterceptor extends AbstractMetricMethodInterceptor<
 	public static final MethodFilter METHOD_FILTER = new AnnotationFilter(ANNOTATION, PROXYABLE_METHODS);
 
 	public ExceptionMeteredMethodInterceptor(final MetricRegistry metricRegistry, final Class<?> targetClass) {
-		super(metricRegistry, targetClass, ANNOTATION, METHOD_FILTER);
+		super(metricRegistry, targetClass, ANNOTATION, METHOD_FILTER, new MeterFactory(), new ExceptionMeteredNamingFactory());
 	}
 
 	@Override
@@ -54,14 +54,18 @@ class ExceptionMeteredMethodInterceptor extends AbstractMetricMethodInterceptor<
 		}
 	}
 
-	@Override
-	protected Meter buildMetric(MetricRegistry metricRegistry, MetricName metricName, ExceptionMetered annotation) {
-		return metricRegistry.meter(metricName);
+	static class MeterFactory implements MetricFactory<Meter, ExceptionMetered> {
+		@Override
+		public Meter getMetric(MetricRegistry metricRegistry, MetricName metricName, ExceptionMetered annotation) {
+			return metricRegistry.meter(metricName);
+		}
 	}
 
-	@Override
-	protected MetricName buildMetricName(Class<?> targetClass, Method method, ExceptionMetered annotation) {
-		return Util.forExceptionMeteredMethod(targetClass, method, annotation);
+	static class ExceptionMeteredNamingFactory implements MetricNamingStrategy<ExceptionMetered> {
+		@Override
+		public MetricName buildMetricName(Class<?> targetClass, Method method, ExceptionMetered annotation) {
+			return Util.forExceptionMeteredMethod(targetClass, method, annotation);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/ryantenney/metrics/spring/MeteredMethodInterceptor.java
+++ b/src/main/java/com/ryantenney/metrics/spring/MeteredMethodInterceptor.java
@@ -37,7 +37,7 @@ class MeteredMethodInterceptor extends AbstractMetricMethodInterceptor<Metered, 
 	public static final MethodFilter METHOD_FILTER = new AnnotationFilter(ANNOTATION, PROXYABLE_METHODS);
 
 	public MeteredMethodInterceptor(final MetricRegistry metricRegistry, final Class<?> targetClass) {
-		super(metricRegistry, targetClass, ANNOTATION, METHOD_FILTER);
+		super(metricRegistry, targetClass, ANNOTATION, METHOD_FILTER, new MeterFactory(), new MeteredNamingStrategy());
 	}
 
 	@Override
@@ -46,14 +46,18 @@ class MeteredMethodInterceptor extends AbstractMetricMethodInterceptor<Metered, 
 		return invocation.proceed();
 	}
 
-	@Override
-	protected Meter buildMetric(MetricRegistry metricRegistry, MetricName metricName, Metered annotation) {
-		return metricRegistry.meter(metricName);
+	static class MeterFactory implements MetricFactory<Meter, Metered> {
+		@Override
+		public Meter getMetric(MetricRegistry metricRegistry, MetricName metricName, Metered annotation) {
+			return metricRegistry.meter(metricName);
+		}
 	}
 
-	@Override
-	protected MetricName buildMetricName(Class<?> targetClass, Method method, Metered annotation) {
-		return Util.forMeteredMethod(targetClass, method, annotation);
+	static class MeteredNamingStrategy implements MetricNamingStrategy<Metered> {
+		@Override
+		public MetricName buildMetricName(Class<?> targetClass, Method method, Metered annotation) {
+			return Util.forMeteredMethod(targetClass, method, annotation);
+		}
 	}
 
 	static AdviceFactory adviceFactory(final MetricRegistry metricRegistry) {

--- a/src/main/java/com/ryantenney/metrics/spring/MetricFactory.java
+++ b/src/main/java/com/ryantenney/metrics/spring/MetricFactory.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ryantenney.metrics.spring;
+
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+
+public interface MetricFactory<T, A> {
+
+	T getMetric(MetricRegistry metricRegistry, MetricName metricName, A annotation);
+
+}

--- a/src/main/java/com/ryantenney/metrics/spring/MetricNamingStrategy.java
+++ b/src/main/java/com/ryantenney/metrics/spring/MetricNamingStrategy.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ryantenney.metrics.spring;
+
+import java.lang.reflect.Method;
+
+import io.dropwizard.metrics.MetricName;
+
+public interface MetricNamingStrategy<A> {
+
+	MetricName buildMetricName(Class<?> targetClass, Method method, A annotation);
+
+}

--- a/src/main/java/com/ryantenney/metrics/spring/MetricsBeanPostProcessorFactory.java
+++ b/src/main/java/com/ryantenney/metrics/spring/MetricsBeanPostProcessorFactory.java
@@ -15,11 +15,16 @@
  */
 package com.ryantenney.metrics.spring;
 
+import java.lang.annotation.Annotation;
+
 import org.springframework.aop.framework.ProxyConfig;
+import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
 
 import io.dropwizard.metrics.health.HealthCheckRegistry;
 
 import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.annotation.Timed;
 
 public class MetricsBeanPostProcessorFactory {
 
@@ -35,7 +40,13 @@ public class MetricsBeanPostProcessorFactory {
 	}
 
 	public static AdvisingBeanPostProcessor timed(final MetricRegistry metricRegistry, final ProxyConfig proxyConfig) {
-		return new AdvisingBeanPostProcessor(TimedMethodInterceptor.POINTCUT, TimedMethodInterceptor.adviceFactory(metricRegistry), proxyConfig);
+		return new AdvisingBeanPostProcessor(new AnnotationMatchingPointcut(null, Timed.class), TimedMethodInterceptor.adviceFactory(metricRegistry, Timed.class, new TimerFactory(), new TimedNamingStrategy()), proxyConfig);
+	}
+
+	public static <A extends Annotation> AdvisingBeanPostProcessor timer(final MetricRegistry metricRegistry, final ProxyConfig proxyConfig, 
+			final Class<A> annotationClass, MetricFactory<Timer, A> timerFactory, MetricNamingStrategy<A> namingStrategy) {
+		return new AdvisingBeanPostProcessor(new AnnotationMatchingPointcut(null, annotationClass), 
+				TimedMethodInterceptor.adviceFactory(metricRegistry, annotationClass, timerFactory, namingStrategy), proxyConfig);
 	}
 
 	public static AdvisingBeanPostProcessor counted(final MetricRegistry metricRegistry, final ProxyConfig proxyConfig) {

--- a/src/main/java/com/ryantenney/metrics/spring/TimedNamingStrategy.java
+++ b/src/main/java/com/ryantenney/metrics/spring/TimedNamingStrategy.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ryantenney.metrics.spring;
+
+import java.lang.reflect.Method;
+
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.annotation.Timed;
+
+public class TimedNamingStrategy implements MetricNamingStrategy<Timed> {
+	@Override
+	public MetricName buildMetricName(Class<?> targetClass, Method method, Timed annotation) {
+		return Util.forTimedMethod(targetClass, method, annotation);
+	}
+
+}

--- a/src/main/java/com/ryantenney/metrics/spring/TimerFactory.java
+++ b/src/main/java/com/ryantenney/metrics/spring/TimerFactory.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ryantenney.metrics.spring;
+
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.annotation.Timed;
+
+public class TimerFactory implements MetricFactory<Timer, Timed> {
+	@Override
+	public Timer getMetric(MetricRegistry metricRegistry, MetricName metricName, Timed annotation) {
+		return metricRegistry.timer(metricName);
+	}
+}

--- a/src/main/java/com/ryantenney/metrics/spring/config/annotation/MetricsConfigurationSupport.java
+++ b/src/main/java/com/ryantenney/metrics/spring/config/annotation/MetricsConfigurationSupport.java
@@ -25,11 +25,16 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.Assert;
 
-import io.dropwizard.metrics.health.HealthCheckRegistry;
+import com.ryantenney.metrics.spring.MetricFactory;
+import com.ryantenney.metrics.spring.MetricNamingStrategy;
+import com.ryantenney.metrics.spring.MetricsBeanPostProcessorFactory;
+import com.ryantenney.metrics.spring.TimedNamingStrategy;
+import com.ryantenney.metrics.spring.TimerFactory;
 
 import io.dropwizard.metrics.MetricRegistry;
-
-import com.ryantenney.metrics.spring.MetricsBeanPostProcessorFactory;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.annotation.Timed;
+import io.dropwizard.metrics.health.HealthCheckRegistry;
 
 /**
  * This is the main class providing the configuration behind the Metrics Java config.
@@ -75,7 +80,19 @@ public class MetricsConfigurationSupport implements ImportAware {
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	public BeanPostProcessor timedAnnotationBeanPostProcessor() {
-		return MetricsBeanPostProcessorFactory.timed(getMetricRegistry(), proxyConfig);
+		return MetricsBeanPostProcessorFactory.timer(getMetricRegistry(), proxyConfig, Timed.class, timedFactory(), timedNamingStrategy());
+	}
+
+	@Bean
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+	public MetricFactory<Timer, Timed> timedFactory() {
+		return new TimerFactory();
+	}
+	
+	@Bean
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+	public MetricNamingStrategy<Timed> timedNamingStrategy() {
+		return new TimedNamingStrategy();
 	}
 
 	@Bean

--- a/src/test/java/com/ryantenney/metrics/spring/TimerCustomizationTest.java
+++ b/src/test/java/com/ryantenney/metrics/spring/TimerCustomizationTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2012 Ryan W Tenney (ryan@10e.us)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.ryantenney.metrics.spring;
 
 import static org.junit.Assert.*;

--- a/src/test/java/com/ryantenney/metrics/spring/TimerCustomizationTest.java
+++ b/src/test/java/com/ryantenney/metrics/spring/TimerCustomizationTest.java
@@ -1,0 +1,160 @@
+package com.ryantenney.metrics.spring;
+
+import static org.junit.Assert.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.aop.framework.ProxyConfig;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.ryantenney.metrics.spring.config.annotation.EnableMetrics;
+import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurer;
+
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.SlidingTimeWindowReservoir;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.annotation.Timed;
+import io.dropwizard.metrics.health.HealthCheckRegistry;
+
+public class TimerCustomizationTest {
+
+	private static AnnotationConfigApplicationContext applicationContext;
+	private static MetricRegistry metricRegistry;
+	private static HealthCheckRegistry healthCheckRegistry;
+	private static Timer defaultAnnotationTimer;
+	private static Timer customAnnotationTimer;
+
+
+	@BeforeClass
+	public static void beforeClass() {
+		metricRegistry = new MetricRegistry();
+		metricRegistry.addListener(new LoggingMetricRegistryListener());
+
+		healthCheckRegistry = new HealthCheckRegistry();
+		
+		defaultAnnotationTimer =new Timer(new SlidingTimeWindowReservoir(30, TimeUnit.MINUTES));
+		customAnnotationTimer =new Timer(new SlidingTimeWindowReservoir(1, TimeUnit.MINUTES));
+
+		applicationContext = new AnnotationConfigApplicationContext(MetricsConfig.class);
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		if (applicationContext != null) {
+			applicationContext.close();
+		}
+	}
+
+
+	@Test
+	public void testDefaultTimedAnnotation() {
+		Timer timer = metricRegistry.getTimers().get(new MetricName("customTimedName.timedMethod"));
+		assertNotNull(timer);
+		assertSame(defaultAnnotationTimer, timer);
+	}
+
+	@Test
+	public void testCustomTimedAnnotation() {
+		Timer timer = metricRegistry.getTimers().get(new MetricName("customTimedAnnotation.customTimedMethod"));
+		assertNotNull(timer);
+		assertSame(customAnnotationTimer, timer);
+	}
+
+	@Configuration
+	@EnableMetrics
+	public static class MetricsConfig implements MetricsConfigurer {
+
+		public static boolean isConfigureReportersInvoked = false;
+
+
+		@Bean
+		public TestBean testBean() {
+			return new TestBean();
+		}
+
+		@Override
+		public MetricRegistry getMetricRegistry() {
+			return metricRegistry;
+		}
+
+		@Override
+		public HealthCheckRegistry getHealthCheckRegistry() {
+			return healthCheckRegistry;
+		}
+
+		@Override
+		public void configureReporters(MetricRegistry metricRegistry) {
+			isConfigureReportersInvoked = true;
+		}
+
+		// Configure a CustomTimed annotation
+		@Bean	
+		public BeanPostProcessor myTimedAnnotationBeanPostProcessor(MetricRegistry metricRegistry) {
+			ProxyConfig proxyConfig = new ProxyConfig();
+			MetricFactory<Timer, CustomTimed> timerFactory = new MetricFactory<Timer, CustomTimed>() {
+			
+				@Override
+				public Timer getMetric(MetricRegistry metricRegistry, MetricName metricName, CustomTimed annotation) {
+					return metricRegistry.register(metricName, customAnnotationTimer);
+				}
+			};
+			MetricNamingStrategy<CustomTimed> namingStrategy = new MetricNamingStrategy<CustomTimed>() {
+				@Override
+				public MetricName buildMetricName(Class<?> targetClass, Method method, CustomTimed annotation) {
+					return new MetricName("customTimedAnnotation."+method.getName());
+				}
+			};
+			return MetricsBeanPostProcessorFactory.timer(metricRegistry, proxyConfig, CustomTimed.class, timerFactory, namingStrategy);
+		}
+
+		// Customize the naming strategy for the default @Timed annotation
+		@Bean
+		public MetricNamingStrategy<Timed> timedNamingStrategy() {
+			return new MetricNamingStrategy<Timed>() {
+				@Override
+				public MetricName buildMetricName(Class<?> targetClass, Method method, Timed annotation) {
+					return new MetricName("customTimedName."+method.getName());
+				}
+			};
+		}
+		
+		// Customize the timer construction for the default @Timed annotation
+		@Bean
+		public MetricFactory<Timer, Timed> timedFactory() {
+			return new MetricFactory<Timer, Timed>() {
+
+				@Override
+				public Timer getMetric(MetricRegistry metricRegistry, MetricName metricName, Timed annotation) {
+					return metricRegistry.register(metricName, defaultAnnotationTimer);
+				}
+			};
+		}
+	}
+
+	public static class TestBean {
+
+		@Timed
+		public void timedMethod() {}
+		
+		@CustomTimed
+		public void customTimedMethod() {}
+	}
+	
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+	public static @interface CustomTimed {
+
+	}
+}


### PR DESCRIPTION
Add extension points to customize the handling of the Timed annotation.

- Move the logic for creating a metric from AbstractMetricMethodInterceptor subclasses to instances of MetricFactory interface.
- Move the logic to get the metric name from AbstractMetricMethodInterceptor subclasses to instances of MetricNamingStrategy.
- Currently only for Timer metric add extension point in MetricsConfigurationSupport to customize the metric name and the Timer creation for the @Timed annotation
- Allow to register a custom annotation with the same behavior of the @Timed annotation.

By registering a custom timedFactory bean is possible for example to change the Reservoir for or the @Timed methods.
By registering multimple custom annotation is possible (for example) to have different Reservoir for different methods.