### PR TITLE
OSGI Service Loader FIX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ryantenney.metrics</groupId>
 	<artifactId>metrics-spring</artifactId>
-	<version>3.1.1-SNAPSHOT</version>
+	<version>3.1.4-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<name>Metrics Spring Integration</name>
 	<description>Spring integration for Coda Hale's Metrics Library</description>

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,8 @@
 							javax.servlet;version="[3.0,4)";resolution:=optional,
 							*]]></Import-Package>
 						<Require-Capability><![CDATA[osgi.extender;
-							filter:="(osgi.extender=osgi.serviceloader.registrar)"]]></Require-Capability>
+							filter:="(|(osgi.extender=osgi.serviceloader.registrar)(osgi.extender=osgi.serviceloader.processor))",
+							osgi.serviceloader;filter:=(osgi.serviceloader=com.ryantenney.metrics.spring.reporter.ReporterElementParser);cardinality:=multiple]]></Require-Capability>
 						<Provide-Capability><![CDATA[osgi.serviceloader;
 							osgi.serviceloader=com.ryantenney.metrics.spring.reporter.ReporterElementParser]]></Provide-Capability>
 					</instructions>


### PR DESCRIPTION
As metrics-spring consumes its own SPI services the OSGI manifest headers need to reflect the fact that the bundle is both producing and consuming its own services.

The current version where the bundle only provides SPI services for other bundles to consume fails when used together with Spring DM in ServiceMix 4.5.3 (Karaf 2.4.1) - Spring is unable to find any SPI Reporter services.

I thus added support for SPI runtime weaving of the spring-metrics bundle so that it consumes its own services. This has been lightly tested (i.e. the spring-metrics bundle is started without failures and the errors in the logs for the bundle using spring-metrics have all disappeared). Currently, however, I have other, unrelated errors blocking further testing and I have yet to see the full metrics-spring working.

I am fairly confident that the change is correct but it would be good to have a second opinion where somebody could test in another OSGI environment to make sure that the dual producer/consumer role does not cause an issue.